### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
-     install_requires=['wget','matplotlib','numpy','pandas','svgpathtools','colourmap','tqdm','fuzzywuzzy[speedup]','sklearn','seaborn'],
+     install_requires=['wget','matplotlib','numpy','pandas','svgpathtools','colourmap','tqdm','rapidfuzz','sklearn','seaborn'],
      python_requires='>=3',
      name='worldmap',
      version=new_version,

--- a/worldmap/utils/deepStringMatching.py
+++ b/worldmap/utils/deepStringMatching.py
@@ -85,8 +85,8 @@
 
  SEE ALSO
    lcs (longest common string)
-   pip install fuzzywuzzy[speedup] #  python-Levenshtein matching
-   fuzzywuzzy
+   pip install rapidfuzz #  python-Levenshtein matching
+   rapidfuzz
 
 """
 
@@ -105,7 +105,7 @@ from tqdm import tqdm
 import worldmap.utils.stringPreprocessing as stringPreprocessing
 
 checkLen = np.vectorize(len) # To check length in arrays
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 #%%
 def deepStringMatching(data, alias, remwords=[], minchar=2, maxchar=25, maxlen=200, scoreOK=1, clean=['complete'], methodtype=['complete'], verbose=1):


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy