### PR TITLE
The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
-     install_requires=['wget','matplotlib','numpy','pandas','svgpathtools','colourmap','tqdm','rapidfuzz','sklearn','seaborn'],
+     install_requires=['wget','matplotlib','numpy','pandas','svgpathtools','colourmap','tqdm','rapidfuzz','scikit-learn','seaborn'],
      python_requires='>=3',
      name='worldmap',
      version=new_version,


### PR DESCRIPTION
Fixes #5 